### PR TITLE
Fix API docs for episode endpoints

### DIFF
--- a/ai_novel/docs/api_endpoint_mapping.md
+++ b/ai_novel/docs/api_endpoint_mapping.md
@@ -91,7 +91,7 @@ APIレスポンスのステータスコードは、以下の基準に従って�
 | 機能 | バックエンドエンドポイント | HTTP メソッド | フロントエンド関数 | 推奨フロントエンドURL |
 |------|--------------------------|--------------|------------------|----------------------|
 | 幕一覧取得 | `/stories/{storyId}/acts/` | GET | `plotApi.getPlot(storyId)` | `/api/story-acts?id={storyId}` |
-| 幕詳細取得 | `/stories/{storyId}/acts/{actId}/` | GET | - | `/api/story-act?story_id={storyId}&act_id={actId}` |
+| 幕詳細取得 | `/stories/{storyId}/acts/{actNumber}/` | GET | - | `/api/story-act?story_id={storyId}&act_id={actNumber}` |
 | プロット生成 | `/stories/{storyId}/create-plot-detail/` | POST | `plotApi.createPlot(storyId)` | `/api/story-create-plot?id={storyId}` |
 | プロット更新 | `/stories/{storyId}/basic-setting/` | PATCH | `plotApi.updatePlotDetail(storyId, data)` | `/api/story-plot-update?id={storyId}` |
 
@@ -99,18 +99,18 @@ APIレスポンスのステータスコードは、以下の基準に従って�
 
 | 機能 | バックエンドエンドポイント | HTTP メソッド | フロントエンド関数 | 推奨フロントエンドURL |
 |------|--------------------------|--------------|------------------|----------------------|
-| エピソード一覧 | `/acts/{actId}/episodes/` | GET | `episodeApi.getEpisodes(storyId)` | `/api/act-episodes?id={actId}` |
-| エピソード詳細 | `/acts/{actId}/episodes/{episodeId}/` | GET | `episodeApi.getEpisode(storyId, episodeId)` | `/api/act-episode?act_id={actId}&episode_id={episodeId}` |
+| エピソード一覧 | `/stories/{storyId}/acts/{actNumber}/episodes/` | GET | `episodeApi.getEpisodes(actNumber)` | `/api/act-episodes?id={actNumber}` |
+| エピソード詳細 | `/stories/{storyId}/acts/{actNumber}/episodes/{episodeNumber}/` | GET | `episodeApi.getEpisode(actNumber, episodeNumber)` | `/api/act-episode?act_id={actNumber}&episode_id={episodeNumber}` |
 | ストーリーのエピソード一覧 | `/stories/{storyId}/episodes/` | GET | - | `/api/story-episodes?id={storyId}` |
-| エピソード生成 | `/stories/{storyId}/create-episode-details/` | POST | `episodeApi.createEpisodes(storyId)` | `/api/story-create-episodes?id={storyId}` |
+| エピソード生成 | `/stories/{storyId}/acts/{actNumber}/episodes/create/` | POST | `episodeApi.createEpisodes(actNumber)` | `/api/story-create-episodes?id={storyId}&act_number={actNumber}` |
 
 ### 7. エピソード本文 (EpisodeContent)
 
 | 機能 | バックエンドエンドポイント | HTTP メソッド | フロントエンド関数 | 推奨フロントエンドURL |
 |------|--------------------------|--------------|------------------|----------------------|
-| 本文取得 | `/episodes/{episodeId}/content/` | GET | `episodeApi.getEpisodeContent(storyId, episodeId)` | `/api/episode-content?id={episodeId}` |
-| 本文生成 | `/stories/{storyId}/create-episode-content/` | POST | `episodeApi.createEpisodeContent(storyId, episodeId)` | `/api/story-create-episode-content?id={storyId}&episode_id={episodeId}` |
-| 本文更新 | `/episodes/{episodeId}/content/` | PATCH | `episodeApi.updateEpisodeContent(storyId, episodeId, data)` | `/api/episode-content-update?id={episodeId}` |
+| 本文取得 | `/stories/{storyId}/acts/{actNumber}/episodes/{episodeNumber}/content/` | GET | `episodeApi.getEpisodeContent(episodeNumber)` | `/api/episode-content?id={episodeNumber}` |
+| 本文生成 | `/stories/{storyId}/acts/{actNumber}/episodes/{episodeNumber}/content/create/` | POST | `episodeApi.createEpisodeContent(episodeNumber)` | `/api/story-create-episode-content?id={storyId}&act_number={actNumber}&episode_id={episodeNumber}` |
+| 本文更新 | `/stories/{storyId}/acts/{actNumber}/episodes/{episodeNumber}/content/` | PATCH | `episodeApi.updateEpisodeContent(episodeNumber, data)` | `/api/episode-content-update?id={episodeNumber}` |
 
 ### 8. タイトル生成 (Title)
 

--- a/ai_novel/docs/episode_content_api.md
+++ b/ai_novel/docs/episode_content_api.md
@@ -13,24 +13,26 @@
 
 | メソッド | エンドポイント | 説明 |
 |---------|--------------|------|
-| GET | `/api/episodes/{episode_id}/content/` | エピソード本文取得 |
-| PUT | `/api/episodes/{episode_id}/content/` | エピソード本文更新 |
-| DELETE | `/api/episodes/{episode_id}/content/` | エピソード本文削除 |
-| POST | `/api/episodes/{episode_id}/generate-content/` | エピソード本文生成 |
+| GET | `/api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/content/` | エピソード本文取得 |
+| PUT | `/api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/content/` | エピソード本文更新 |
+| DELETE | `/api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/content/` | エピソード本文削除 |
+| POST | `/api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/content/create/` | エピソード本文生成 |
 
 ## エピソード本文取得
 
 ### リクエスト
 
 ```http
-GET /api/episodes/{episode_id}/content/
+GET /api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/content/
 ```
 
 #### URLパラメータ
 
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
-| episode_id | integer | はい | エピソードID |
+| story_id | integer | はい | ストーリーID |
+| act_number | integer | はい | 幕番号 |
+| episode_number | integer | はい | エピソード番号 |
 
 ### レスポンス
 
@@ -59,14 +61,16 @@ GET /api/episodes/{episode_id}/content/
 ### リクエスト
 
 ```http
-PUT /api/episodes/{episode_id}/content/
+PUT /api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/content/
 ```
 
 #### URLパラメータ
 
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
-| episode_id | integer | はい | エピソードID |
+| story_id | integer | はい | ストーリーID |
+| act_number | integer | はい | 幕番号 |
+| episode_number | integer | はい | エピソード番号 |
 
 #### リクエストボディ
 
@@ -107,14 +111,16 @@ PUT /api/episodes/{episode_id}/content/
 ### リクエスト
 
 ```http
-DELETE /api/episodes/{episode_id}/content/
+DELETE /api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/content/
 ```
 
 #### URLパラメータ
 
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
-| episode_id | integer | はい | エピソードID |
+| story_id | integer | はい | ストーリーID |
+| act_number | integer | はい | 幕番号 |
+| episode_number | integer | はい | エピソード番号 |
 
 ### レスポンス
 
@@ -135,14 +141,16 @@ DELETE /api/episodes/{episode_id}/content/
 ### リクエスト
 
 ```http
-POST /api/episodes/{episode_id}/generate-content/
+POST /api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/content/create/
 ```
 
 #### URLパラメータ
 
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
-| episode_id | integer | はい | エピソードID |
+| story_id | integer | はい | ストーリーID |
+| act_number | integer | はい | 幕番号 |
+| episode_number | integer | はい | エピソード番号 |
 
 #### リクエストボディ
 

--- a/ai_novel/docs/episode_management_api.md
+++ b/ai_novel/docs/episode_management_api.md
@@ -15,19 +15,19 @@
 
 | メソッド | エンドポイント | 説明 |
 |---------|--------------|------|
-| GET | `/api/stories/{story_id}/acts/{act_id}/episodes/` | エピソード一覧取得 |
-| POST | `/api/stories/{story_id}/acts/{act_id}/create-episodes/` | 複数エピソード一括作成（AI）|
-| POST | `/api/stories/{story_id}/acts/{act_id}/episodes/new/` | 単一エピソード作成 |
-| GET | `/api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/` | エピソード詳細取得 |
-| PUT | `/api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/` | エピソード更新 |
-| DELETE | `/api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/` | エピソード削除 |
+| GET | `/api/stories/{story_id}/acts/{act_number}/episodes/` | エピソード一覧取得 |
+| POST | `/api/stories/{story_id}/acts/{act_number}/episodes/create/` | 複数エピソード一括作成（AI）|
+| POST | `/api/stories/{story_id}/acts/{act_number}/episodes/` | 単一エピソード作成 |
+| GET | `/api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/` | エピソード詳細取得 |
+| PUT | `/api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/` | エピソード更新 |
+| DELETE | `/api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/` | エピソード削除 |
 
 ## 1. エピソード一覧取得 API
 
 ### リクエスト
 
 ```http
-GET /api/stories/{story_id}/acts/{act_id}/episodes/
+GET /api/stories/{story_id}/acts/{act_number}/episodes/
 ```
 
 #### URLパラメータ
@@ -35,7 +35,7 @@ GET /api/stories/{story_id}/acts/{act_id}/episodes/
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
 | story_id | integer | はい | ストーリーID |
-| act_id | integer | はい | 幕ID |
+| act_number | integer | はい | 幕番号 |
 
 ### レスポンス
 
@@ -99,7 +99,7 @@ GET /api/stories/{story_id}/acts/{act_id}/episodes/
 ### リクエスト
 
 ```http
-POST /api/stories/{story_id}/acts/{act_id}/create-episodes/
+POST /api/stories/{story_id}/acts/{act_number}/episodes/create/
 ```
 
 #### URLパラメータ
@@ -107,7 +107,7 @@ POST /api/stories/{story_id}/acts/{act_id}/create-episodes/
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
 | story_id | integer | はい | ストーリーID |
-| act_id | integer | はい | 幕ID |
+| act_number | integer | はい | 幕番号 |
 
 #### リクエストボディ
 
@@ -196,7 +196,7 @@ POST /api/stories/{story_id}/acts/{act_id}/create-episodes/
 ### リクエスト
 
 ```http
-POST /api/stories/{story_id}/acts/{act_id}/episodes/new/
+POST /api/stories/{story_id}/acts/{act_number}/episodes/
 ```
 
 #### URLパラメータ
@@ -204,7 +204,7 @@ POST /api/stories/{story_id}/acts/{act_id}/episodes/new/
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
 | story_id | integer | はい | ストーリーID |
-| act_id | integer | はい | 幕ID |
+| act_number | integer | はい | 幕番号 |
 
 #### リクエストボディ
 
@@ -249,7 +249,7 @@ POST /api/stories/{story_id}/acts/{act_id}/episodes/new/
 ### リクエスト (詳細取得)
 
 ```http
-GET /api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/
+GET /api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/
 ```
 
 #### URLパラメータ
@@ -257,8 +257,8 @@ GET /api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
 | story_id | integer | はい | ストーリーID |
-| act_id | integer | はい | 幕ID |
-| episode_id | integer | はい | エピソードID |
+| act_number | integer | はい | 幕番号 |
+| episode_number | integer | はい | エピソード番号 |
 
 ### レスポンス (詳細取得)
 
@@ -289,7 +289,7 @@ GET /api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/
 ### リクエスト (更新)
 
 ```http
-PUT /api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/
+PUT /api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/
 ```
 
 #### URLパラメータ
@@ -297,8 +297,8 @@ PUT /api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
 | story_id | integer | はい | ストーリーID |
-| act_id | integer | はい | 幕ID |
-| episode_id | integer | はい | エピソードID |
+| act_number | integer | はい | 幕番号 |
+| episode_number | integer | はい | エピソード番号 |
 
 #### リクエストボディ (通常更新)
 
@@ -352,7 +352,7 @@ PUT /api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/
 ### リクエスト (削除)
 
 ```http
-DELETE /api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/
+DELETE /api/stories/{story_id}/acts/{act_number}/episodes/{episode_number}/
 ```
 
 #### URLパラメータ
@@ -360,8 +360,8 @@ DELETE /api/stories/{story_id}/acts/{act_id}/episodes/{episode_id}/
 | パラメータ | 型 | 必須 | 説明 |
 |----------|---|------|-----|
 | story_id | integer | はい | ストーリーID |
-| act_id | integer | はい | 幕ID |
-| episode_id | integer | はい | エピソードID |
+| act_number | integer | はい | 幕番号 |
+| episode_number | integer | はい | エピソード番号 |
 
 ### レスポンス (削除)
 


### PR DESCRIPTION
## Summary
- sync episode content and management API docs with backend URLs
- update mapping table to reflect nested episode routes

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to standardize endpoint URL structures, replacing ID-based parameters with numbered identifiers for acts and episodes.
  - Clarified and unified parameter naming conventions and example requests across plot, episode, and episode content APIs.
  - Improved consistency in frontend and backend API documentation for easier reference and understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->